### PR TITLE
fix(auth): sign up without email confirmation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ coverage/
 *.njsproj
 *.sln
 *.sw?
+.vercel

--- a/src/features/auth/hooks/useSignUp.ts
+++ b/src/features/auth/hooks/useSignUp.ts
@@ -3,17 +3,15 @@ import { signUp } from "../AuthService";
 import { SIGN_UP } from "../constants";
 import { SignUpRequest } from "../interfaces/requests/sign-up-request.interface";
 
-import { useNavigate } from "react-router-dom";
 import { useLogIn } from "./useLogIn";
 
 export const useSignUp = () => {
-  const navigate = useNavigate();
-  const { isPending: isSigningIn } = useLogIn();
+  const { signIn, isPending: isSigningIn } = useLogIn();
   const { mutateAsync, isPending: isSigningUp } = useMutation({
     mutationKey: [SIGN_UP],
     mutationFn: (request: SignUpRequest) => signUp(request),
-    onSuccess: async () => {
-      navigate("/auth/confirm-email");
+    onSuccess: async (_: unknown, request: SignUpRequest) => {
+      await signIn({ email: request.email, password: request.password });
     },
   });
 


### PR DESCRIPTION
Al crear el usuario, se llama al endpoint para iniciar sesión así se evita un "_doble_" inicio de sesión por parte del usuario y el flujo es más directo